### PR TITLE
feat(view-preferences): Add sync view for cross devices

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ before:
 
 builds:
   - env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
 
     binary: cloudreve
 

--- a/ent/schema/user.go
+++ b/ent/schema/user.go
@@ -52,6 +52,7 @@ func (User) Edges() []ent.Edge {
 		edge.To("passkey", Passkey.Type),
 		edge.To("tasks", Task.Type),
 		edge.To("entities", Entity.Type),
+		edge.To("view_preferences", ViewPreference.Type),
 	}
 }
 

--- a/ent/schema/viewpreference.go
+++ b/ent/schema/viewpreference.go
@@ -1,0 +1,70 @@
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/edge"
+	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
+)
+
+// ViewPreference holds the schema definition for the ViewPreference entity.
+type ViewPreference struct {
+	ent.Schema
+}
+
+// Mixin of the ViewPreference.
+func (ViewPreference) Mixin() []ent.Mixin {
+	return []ent.Mixin{
+		CommonMixin{},
+	}
+}
+
+// Fields of the ViewPreference.
+func (ViewPreference) Fields() []ent.Field {
+	return []ent.Field{
+		field.String("folder_path").
+			NotEmpty().
+			Comment("The folder path this preference applies to"),
+		field.String("layout").
+			Default("grid").
+			Comment("View layout (grid/list/gallery)"),
+		field.Bool("show_thumb").
+			Default(true).
+			Comment("Show thumbnails in grid view"),
+		field.String("sort_by").
+			Default("created_at").
+			Comment("Sort field"),
+		field.String("sort_direction").
+			Default("asc").
+			Comment("Sort direction (asc/desc)"),
+		field.Int("page_size").
+			Default(100).
+			Comment("Pagination size"),
+		field.Int("gallery_width").
+			Default(220).
+			Comment("Gallery view image width"),
+		field.String("list_columns").
+			Default("").
+			Comment("List view column settings as JSON string"),
+	}
+}
+
+// Edges of the ViewPreference.
+func (ViewPreference) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.From("user", User.Type).
+			Ref("view_preferences").
+			Required().
+			Unique(),
+	}
+}
+
+// Indexes of the ViewPreference.
+func (ViewPreference) Indexes() []ent.Index {
+	return []ent.Index{
+		// Composite unique index on user and folder_path
+		index.Fields("folder_path").
+			Edges("user").
+			Unique(),
+	}
+}

--- a/inventory/types/types.go
+++ b/inventory/types/types.go
@@ -14,6 +14,7 @@ type (
 		VersionRetentionMax int         `json:"version_retention_max,omitempty"`
 		Pined               []PinedFile `json:"pined,omitempty"`
 		Language            string      `json:"email_language,omitempty"`
+		SyncViewPreferences bool        `json:"sync_view_preferences,omitempty"`
 	}
 
 	PinedFile struct {

--- a/routers/controllers/user.go
+++ b/routers/controllers/user.go
@@ -407,3 +407,31 @@ func ListPublicShare(c *gin.Context) {
 		})
 	}
 }
+
+// GetViewPreference retrieves view preferences for a folder
+func GetViewPreference(c *gin.Context) {
+	service := ParametersFromContext[*user.GetViewPreferenceService](c, user.GetViewPreferenceParamCtx{})
+	res, err := service.Get(c)
+	if err != nil {
+		c.JSON(200, serializer.Err(c, err))
+		c.Abort()
+		return
+	}
+
+	c.JSON(200, serializer.Response{
+		Data: res,
+	})
+}
+
+// SetViewPreference updates view preferences for a folder
+func SetViewPreference(c *gin.Context) {
+	service := ParametersFromContext[*user.SetViewPreferenceService](c, user.SetViewPreferenceParamCtx{})
+	err := service.Set(c)
+	if err != nil {
+		c.JSON(200, serializer.Err(c, err))
+		c.Abort()
+		return
+	}
+
+	c.JSON(200, serializer.Response{})
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -1107,6 +1107,16 @@ func initMasterRouter(dep dependency.Dep) *gin.Engine {
 					)
 					// 获得二步验证初始化信息
 					setting.GET("2fa", controllers.UserInit2FA)
+
+					// View preferences
+					setting.POST("view-preference",
+						controllers.FromJSON[usersvc.GetViewPreferenceService](usersvc.GetViewPreferenceParamCtx{}),
+						controllers.GetViewPreference,
+					)
+					setting.PUT("view-preference",
+						controllers.FromJSON[usersvc.SetViewPreferenceService](usersvc.SetViewPreferenceParamCtx{}),
+						controllers.SetViewPreference,
+					)
 				}
 			}
 

--- a/service/user/response.go
+++ b/service/user/response.go
@@ -28,6 +28,7 @@ type UserSettings struct {
 	Paswordless             bool      `json:"passwordless"`
 	TwoFAEnabled            bool      `json:"two_fa_enabled"`
 	Passkeys                []Passkey `json:"passkeys,omitempty"`
+	SyncViewPreferences     bool      `json:"sync_view_preferences"`
 }
 
 func BuildUserSettings(u *ent.User, passkeys []*ent.Passkey, parser *uaparser.Parser) *UserSettings {
@@ -40,6 +41,7 @@ func BuildUserSettings(u *ent.User, passkeys []*ent.Passkey, parser *uaparser.Pa
 		Passkeys: lo.Map(passkeys, func(item *ent.Passkey, index int) Passkey {
 			return BuildPasskey(item)
 		}),
+		SyncViewPreferences: u.Settings.SyncViewPreferences,
 	}
 }
 

--- a/service/user/setting.go
+++ b/service/user/setting.go
@@ -4,6 +4,13 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/cloudreve/Cloudreve/v4/application/dependency"
 	"github.com/cloudreve/Cloudreve/v4/ent"
 	"github.com/cloudreve/Cloudreve/v4/inventory"
@@ -15,12 +22,6 @@ import (
 	"github.com/cloudreve/Cloudreve/v4/pkg/util"
 	"github.com/gin-gonic/gin"
 	"github.com/pquerna/otp/totp"
-	"io"
-	"net/http"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 const (
@@ -219,6 +220,7 @@ type (
 		NewPassword             *string   `json:"new_password" binding:"omitempty,min=6,max=128"`
 		TwoFAEnabled            *bool     `json:"two_fa_enabled" binding:"omitempty"`
 		TwoFACode               *string   `json:"two_fa_code" binding:"omitempty"`
+		SyncViewPreferences     *bool     `json:"sync_view_preferences" binding:"omitempty"`
 	}
 	PatchUserSettingParamsCtx struct{}
 )
@@ -257,6 +259,11 @@ func (s *PatchUserSetting) Patch(c *gin.Context) error {
 
 	if s.VersionRetentionMax != nil {
 		u.Settings.VersionRetentionMax = *s.VersionRetentionMax
+		saveSetting = true
+	}
+
+	if s.SyncViewPreferences != nil {
+		u.Settings.SyncViewPreferences = *s.SyncViewPreferences
 		saveSetting = true
 	}
 

--- a/service/user/viewpreference.go
+++ b/service/user/viewpreference.go
@@ -1,0 +1,283 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"path/filepath"
+
+	"github.com/cloudreve/Cloudreve/v4/application/dependency"
+	"github.com/cloudreve/Cloudreve/v4/inventory"
+	"github.com/cloudreve/Cloudreve/v4/pkg/serializer"
+	"github.com/gin-gonic/gin"
+)
+
+// ViewPreferenceData represents view preferences for a folder
+type ViewPreferenceData struct {
+	Layout        string `json:"layout,omitempty"`
+	ShowThumb     bool   `json:"show_thumb"`
+	SortBy        string `json:"sort_by,omitempty"`
+	SortDirection string `json:"sort_direction,omitempty"`
+	PageSize      int    `json:"page_size,omitempty"`
+	GalleryWidth  int    `json:"gallery_width,omitempty"`
+	ListColumns   string `json:"list_columns,omitempty"`
+}
+
+// ViewPreferenceResponse represents the API response for view preferences
+type ViewPreferenceResponse struct {
+	Layout        string `json:"layout,omitempty"`
+	ShowThumb     bool   `json:"show_thumb"`
+	SortBy        string `json:"sort_by,omitempty"`
+	SortDirection string `json:"sort_direction,omitempty"`
+	PageSize      int    `json:"page_size,omitempty"`
+	GalleryWidth  int    `json:"gallery_width,omitempty"`
+	ListColumns   string `json:"list_columns,omitempty"`
+}
+
+// makeViewPrefKey creates a key for storing view preferences
+func makeViewPrefKey(userID int, folderPath string) string {
+	return fmt.Sprintf("view_pref_%d_%s", userID, folderPath)
+}
+
+// GetFolderViewPreference retrieves view preferences for a specific folder
+func GetFolderViewPreference(c *gin.Context, folderPath string) (*ViewPreferenceData, error) {
+	user := inventory.UserFromContext(c)
+	dep := dependency.FromContext(c)
+
+	// Check if user has sync enabled
+	if !user.Settings.SyncViewPreferences {
+		// Return default preferences when sync is disabled
+		return getDefaultViewPreference(), nil
+	}
+
+	// Normalize folder path
+	folderPath = path.Clean(folderPath)
+	if folderPath == "." {
+		folderPath = "/"
+	}
+
+	// Try to get preferences from KV store
+	kv := dep.KV()
+	key := makeViewPrefKey(user.ID, folderPath)
+
+	data, ok := kv.Get(key)
+	if !ok {
+		// If not found for this path, try parent paths
+		if folderPath != "/" {
+			parentPath := path.Dir(folderPath)
+			return GetFolderViewPreference(c, parentPath)
+		}
+		// Return default if no preferences found
+		return getDefaultViewPreference(), nil
+	}
+
+	// Parse the stored JSON
+	var prefs ViewPreferenceData
+	if jsonData, ok := data.(string); ok {
+		if err := json.Unmarshal([]byte(jsonData), &prefs); err != nil {
+			return getDefaultViewPreference(), nil
+		}
+		return &prefs, nil
+	}
+
+	return getDefaultViewPreference(), nil
+}
+
+// SetFolderViewPreference saves or updates view preferences for a folder
+func SetFolderViewPreference(c *gin.Context, folderPath string, prefs *ViewPreferenceData) error {
+	user := inventory.UserFromContext(c)
+	dep := dependency.FromContext(c)
+
+	// Check if user has sync enabled
+	if !user.Settings.SyncViewPreferences {
+		// Silently do nothing when sync is disabled
+		return nil
+	}
+
+	// Normalize folder path
+	folderPath = path.Clean(folderPath)
+	if folderPath == "." {
+		folderPath = "/"
+	}
+
+	// Check if preferences are same as parent
+	if folderPath != "/" {
+		parentPath := path.Dir(folderPath)
+		parentPrefs, _ := GetFolderViewPreference(c, parentPath)
+		if isPreferenceEqual(prefs, parentPrefs) {
+			// Remove redundant preference
+			kv := dep.KV()
+			key := makeViewPrefKey(user.ID, folderPath)
+			kv.Delete(key)
+			return nil
+		}
+	}
+
+	// Store preferences in KV store
+	kv := dep.KV()
+	key := makeViewPrefKey(user.ID, folderPath)
+
+	jsonData, err := json.Marshal(prefs)
+	if err != nil {
+		return serializer.NewError(serializer.CodeInternalSetting, "Failed to serialize preferences", err)
+	}
+
+	// Store with no expiration (0 means permanent)
+	if err := kv.Set(key, string(jsonData), 0); err != nil {
+		return serializer.NewError(serializer.CodeInternalSetting, "Failed to store preferences", err)
+	}
+
+	return nil
+}
+
+// DeleteFolderViewPreferences deletes all view preferences for folders with the given paths
+func DeleteFolderViewPreferences(ctx context.Context, userID int, folderPaths []string) error {
+	if len(folderPaths) == 0 {
+		return nil
+	}
+
+	dep := dependency.FromContext(ctx)
+	kv := dep.KV()
+
+	// Normalize folder paths and create keys
+	keys := make([]string, 0, len(folderPaths))
+	for _, folderPath := range folderPaths {
+		folderPath = path.Clean(folderPath)
+		if folderPath == "." {
+			folderPath = "/"
+		}
+		keys = append(keys, makeViewPrefKey(userID, folderPath))
+	}
+
+	// Delete all keys
+	for _, key := range keys {
+		kv.Delete(key)
+	}
+	return nil
+}
+
+// getDefaultViewPreference returns the default view preferences
+func getDefaultViewPreference() *ViewPreferenceData {
+	return &ViewPreferenceData{
+		Layout:        "grid",
+		ShowThumb:     true,
+		SortBy:        "created_at",
+		SortDirection: "asc",
+		PageSize:      100,
+		GalleryWidth:  220,
+		ListColumns:   "",
+	}
+}
+
+// isPreferenceEqual checks if two view preferences are equal
+func isPreferenceEqual(a, b *ViewPreferenceData) bool {
+	if a.Layout != b.Layout || a.ShowThumb != b.ShowThumb ||
+		a.SortBy != b.SortBy || a.SortDirection != b.SortDirection ||
+		a.PageSize != b.PageSize || a.GalleryWidth != b.GalleryWidth ||
+		a.ListColumns != b.ListColumns {
+		return false
+	}
+
+	return true
+}
+
+// ViewPreferenceService handles view preference API requests
+type (
+	// GetViewPreferenceService Service to get view preferences for a folder
+	GetViewPreferenceService struct {
+		Path string `json:"path" binding:"required"`
+	}
+	GetViewPreferenceParamCtx struct{}
+
+	// SetViewPreferenceService Service to set view preferences for a folder
+	SetViewPreferenceService struct {
+		Path          string  `json:"path" binding:"required"`
+		Layout        *string `json:"layout" binding:"omitempty,oneof=grid list gallery"`
+		ShowThumb     *bool   `json:"show_thumb" binding:"omitempty"`
+		SortBy        *string `json:"sort_by" binding:"omitempty"`
+		SortDirection *string `json:"sort_direction" binding:"omitempty,oneof=asc desc"`
+		PageSize      *int    `json:"page_size" binding:"omitempty,min=10,max=2000"`
+		GalleryWidth  *int    `json:"gallery_width" binding:"omitempty,min=50,max=500"`
+		ListColumns   *string `json:"list_columns" binding:"omitempty"`
+	}
+	SetViewPreferenceParamCtx struct{}
+)
+
+// GetViewPreference retrieves view preferences for a folder with inheritance
+func (s *GetViewPreferenceService) Get(c *gin.Context) (*ViewPreferenceResponse, error) {
+	u := inventory.UserFromContext(c)
+
+	// If sync is disabled, return empty response
+	if !u.Settings.SyncViewPreferences {
+		return &ViewPreferenceResponse{}, nil
+	}
+
+	// Clean and validate the path
+	path := filepath.Clean(s.Path)
+	if path == "." {
+		path = "/"
+	}
+
+	// Get view preferences
+	prefs, err := GetFolderViewPreference(c, path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create response
+	response := &ViewPreferenceResponse{
+		Layout:        prefs.Layout,
+		ShowThumb:     prefs.ShowThumb,
+		SortBy:        prefs.SortBy,
+		SortDirection: prefs.SortDirection,
+		PageSize:      prefs.PageSize,
+		GalleryWidth:  prefs.GalleryWidth,
+		ListColumns:   prefs.ListColumns,
+	}
+
+	return response, nil
+}
+
+// Set updates view preferences for a folder
+func (s *SetViewPreferenceService) Set(c *gin.Context) error {
+	u := inventory.UserFromContext(c)
+
+	// If sync is disabled, do nothing
+	if !u.Settings.SyncViewPreferences {
+		return nil
+	}
+
+	// Clean and validate the path
+	path := filepath.Clean(s.Path)
+	if path == "." {
+		path = "/"
+	}
+
+	// Build preference data from request
+	data := ViewPreferenceData{}
+
+	if s.Layout != nil {
+		data.Layout = *s.Layout
+	}
+	if s.ShowThumb != nil {
+		data.ShowThumb = *s.ShowThumb
+	}
+	if s.SortBy != nil {
+		data.SortBy = *s.SortBy
+	}
+	if s.SortDirection != nil {
+		data.SortDirection = *s.SortDirection
+	}
+	if s.PageSize != nil {
+		data.PageSize = *s.PageSize
+	}
+	if s.GalleryWidth != nil {
+		data.GalleryWidth = *s.GalleryWidth
+	}
+	if s.ListColumns != nil {
+		data.ListColumns = *s.ListColumns
+	}
+
+	return SetFolderViewPreference(c, path, &data)
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing view preferences, along with several supporting changes across the codebase. The most significant updates include adding a new `ViewPreference` schema, implementing APIs for retrieving and updating view preferences, and extending user settings to support synchronization of view preferences.

### **Feature: View Preferences Management**
* [`ent/schema/viewpreference.go`](diffhunk://#diff-2ccead7aefe399c6126604cd409ffe80433556f12f044c802088bfa0f95a4943R1-R70): Added a new schema for `ViewPreference`, including fields for folder path, layout, sorting options, pagination, and gallery settings. Also added edges to associate preferences with users and a composite unique index for user and folder path.
* [`service/user/viewpreference.go`](diffhunk://#diff-7df1e97cd8e7bebcb660a1874e427f80b5101228fb74c4335748c3c87c6b1e03R1-R283): Implemented functionality to get, set, and delete view preferences for folders, including inheritance logic for preferences. Added services for handling API requests related to view preferences.

### **API Endpoints**
* [`routers/controllers/user.go`](diffhunk://#diff-29ca1f8e568411beb4e1667a9aff9da34fbc1f0818d30fcbe20e2b536678779bR410-R437): Added two new API endpoints, `GetViewPreference` and `SetViewPreference`, for retrieving and updating view preferences.
* [`routers/router.go`](diffhunk://#diff-4bb1f3889791d48e3a1866a36aca485a8bf94a73d02e0950f32b69c8004edd2aR1110-R1119): Registered the new view preference endpoints (`POST` and `PUT`) under the `setting` route.

### **User Settings Enhancements**
* [`inventory/types/types.go`](diffhunk://#diff-96f750c7c15a7d50c26fc246c9f56d590a1b3725d2e27229c2e59a67b611e18fR17): Added a new field `SyncViewPreferences` to the `Settings` struct to enable or disable synchronization of view preferences.
* [`service/user/response.go`](diffhunk://#diff-13d2426492536748d20d5e5eaa902f624e07f160922d2f590ed6cb609e109ebbR31): Included `SyncViewPreferences` in the `UserSettings` response object and populated it from the user entity. [[1]](diffhunk://#diff-13d2426492536748d20d5e5eaa902f624e07f160922d2f590ed6cb609e109ebbR31) [[2]](diffhunk://#diff-13d2426492536748d20d5e5eaa902f624e07f160922d2f590ed6cb609e109ebbR44)
* [`service/user/setting.go`](diffhunk://#diff-da6aa9ab812d23d11b1e419e406614a07b44b818cd554bd7373ab9cb93c07cd8R223): Added logic to update the `SyncViewPreferences` field in user settings. [[1]](diffhunk://#diff-da6aa9ab812d23d11b1e419e406614a07b44b818cd554bd7373ab9cb93c07cd8R223) [[2]](diffhunk://#diff-da6aa9ab812d23d11b1e419e406614a07b44b818cd554bd7373ab9cb93c07cd8R265-R269)

### **Schema Updates**
* [`ent/schema/user.go`](diffhunk://#diff-c5fc389a809e819c5217697a1711b202bfb7f5594a14da80cdabad8b8c6a939cR55): Added an edge from `User` to `ViewPreference` to establish a relationship between users and their view preferences.… for folders